### PR TITLE
Create appliance interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is critical that great care be taken before adding code to this repository, s
 ## Included in this repository
 
 * `errors/*` - Errors that thrown by the interfaces defined in this repo.
+* `interfaces/*` - Interfaces used by the TV Kitchen.
 
 ## NOT included in this repository
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export * as errors from './errors'
+export * as interfaces from './interfaces'

--- a/src/interfaces/IAppliance.js
+++ b/src/interfaces/IAppliance.js
@@ -1,0 +1,96 @@
+import {
+	InterfaceInstantiationError,
+	NotImplementedError,
+} from '../errors'
+
+class IAppliance {
+	/**
+	 * Constructor for a new appliance.
+	 *
+	 * @param  {Object} overrideSettings Values to override default appliance settings.
+	 */
+	// eslint-disable-next-line no-unused-vars
+	constructor(overrideSettings = {}) {
+		if (this.constructor === IAppliance) {
+			throw new InterfaceInstantiationError(this.constructor.name)
+		}
+	}
+
+	/**
+	 * Getter for the list of data types accepted by the appliance.
+	 *
+	 * @return {String[]} The list of data types accepted by the appliance.
+	 */
+	getInputTypes = () => {
+		throw new NotImplementedError('getInputTypes')
+	}
+
+	/**
+	 * Getter for the list of data types produced by the appliance.
+	 *
+	 * @return {String[]} The list of data types produced by the appliance.
+	 */
+	getOutputTypes = () => {
+		throw new NotImplementedError('getOutputTypes')
+	}
+
+	/**
+	 * Asserts that a given payload is actually a payload.
+   *
+	 * @param  {Payload} payload The payload that we want to validate.
+	 * @return {Boolean}         The result of the validation check.
+	 */
+	// eslint-disable-next-line no-unused-vars
+	isValidPayload = async (payload) => {
+		throw new NotImplementedError('isValidPayload')
+	}
+
+	/**
+	 * Invokes the appliance on any unprocessed data in the appliance buffer.
+	 *
+	 * @return {Boolean} True if the appliance procesed data; False if the appliance needs more data.
+	 */
+	invoke = async () => {
+		throw new NotImplementedError('invoke')
+	}
+
+	/**
+	 * Called to pass data into the appliance. If the payload is valid, it is added
+	 * to the buffer and the appliance is invoked.
+	 *
+	 * @param  {Payload} payload The payload to be ingested.
+	 * @return {Boolean}         Whether the payload resulted in a successful invocation.
+	 * @throws {AssertionError} when passed an invalid payload for this appliance.
+	 */
+	// eslint-disable-next-line no-unused-vars
+	ingestPayload = async (payload) => {
+		throw new NotImplementedError('ingestPayload')
+	}
+
+	/**
+	 * Registers a listener to the appliance for a given event type.
+	 *
+	 * Event types are listed in constants/events.js
+	 *
+	 * @param  {String} eventType  The type of event being listened to.
+	 * @param  {Function} listener The listener to be registered for that event.
+	 * @return {EventEmitter}      The EventEmitter (so events can be chained).
+	 */
+	// eslint-disable-next-line no-unused-vars
+	on = (eventType, listener) => {
+		throw new NotImplementedError('on')
+	}
+
+	/**
+	 * Called by an implemented appliance when there is data worth sharing.
+	 *
+	 * @param  {Payload} payload The result that is ready to share.
+	 * @return {Boolean}         Returns true if there are output listeners, false otherwise.
+	 */
+	// eslint-disable-next-line no-unused-vars
+	emitResult = (payload) => {
+		throw new NotImplementedError('emitResult')
+	}
+}
+
+export default IAppliance

--- a/src/interfaces/__test__/IAppliance.test.js
+++ b/src/interfaces/__test__/IAppliance.test.js
@@ -1,0 +1,117 @@
+import { IAppliance } from '..'
+import {
+	InterfaceInstantiationError,
+	NotImplementedError,
+} from '../../errors'
+import {
+	FullyImplementedAppliance,
+	PartiallyImplementedAppliance,
+} from './classes'
+
+describe('IAppliance', () => {
+	describe('constructor', () => {
+		it('should throw an error when called directly', () => {
+			expect(() => {
+				new IAppliance() // eslint-disable-line no-new
+			}).toThrow(InterfaceInstantiationError)
+		})
+
+		it('should throw an error when getInputTypes() is called without implementation', () => {
+			const implementedAppliance = new PartiallyImplementedAppliance()
+			expect(() => implementedAppliance.getInputTypes()).toThrow(NotImplementedError)
+		})
+
+		it('should allow construction when extended', () => {
+			expect(() => {
+				new PartiallyImplementedAppliance() // eslint-disable-line no-new
+			}).not.toThrow(Error)
+		})
+	})
+
+	describe('getOutputTypes', () => {
+		it('should throw an error when called without implementation', () => {
+			const appliance = new PartiallyImplementedAppliance()
+			expect(() => appliance.getOutputTypes()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(() => appliance.getOutputTypes()).not.toThrow(NotImplementedError)
+		})
+	})
+
+	describe('isValidPayload', () => {
+		it('should throw an error when called without implementation', async () => {
+			const appliance = new PartiallyImplementedAppliance()
+			await expect(async () => appliance.isValidPayload())
+				.rejects.toBeInstanceOf(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', async () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.isValidPayload()).toBeDefined()
+		})
+	})
+
+	describe('invoke', () => {
+		it('should throw an error when called without implementation', async () => {
+			const appliance = new PartiallyImplementedAppliance()
+			await expect(async () => appliance.invoke())
+				.rejects.toBeInstanceOf(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', async () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.invoke()).toBeDefined()
+		})
+	})
+
+	describe('ingestPayload', () => {
+		it('should throw an error when called without implementation', async () => {
+			const appliance = new PartiallyImplementedAppliance()
+			await expect(async () => appliance.ingestPayload())
+				.rejects.toBeInstanceOf(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', async () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.ingestPayload()).toBeDefined()
+		})
+	})
+
+	describe('getInputTypes', () => {
+		it('should throw an error when called without implementation', () => {
+			const appliance = new PartiallyImplementedAppliance()
+			expect(() => appliance.getInputTypes()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(() => appliance.getInputTypes()).not.toThrow(NotImplementedError)
+		})
+	})
+
+	describe('on', () => {
+		it('should throw an error when called without implementation', () => {
+			const appliance = new PartiallyImplementedAppliance()
+			expect(() => appliance.on()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(() => appliance.on()).not.toThrow(NotImplementedError)
+		})
+	})
+
+	describe('emitResult', () => {
+		it('should throw an error when called without implementation', () => {
+			const appliance = new PartiallyImplementedAppliance()
+			expect(() => appliance.emitResult()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(() => appliance.emitResult()).not.toThrow(NotImplementedError)
+		})
+	})
+})

--- a/src/interfaces/__test__/classes/FullyImplementedAppliance.js
+++ b/src/interfaces/__test__/classes/FullyImplementedAppliance.js
@@ -1,0 +1,19 @@
+import IAppliance from '../../IAppliance'
+
+class FullyImplementedAppliance extends IAppliance {
+	getInputTypes = () => []
+
+	getOutputTypes = () => []
+
+	isValidPayload = async () => true
+
+	invoke = async () => true
+
+	ingestPayload = async () => true
+
+	on = () => true
+
+	emitResult = () => true
+}
+
+export default FullyImplementedAppliance

--- a/src/interfaces/__test__/classes/PartiallyImplementedAppliance.js
+++ b/src/interfaces/__test__/classes/PartiallyImplementedAppliance.js
@@ -1,0 +1,5 @@
+import IAppliance from '../../IAppliance'
+
+class PartiallyImplementedAppliance extends IAppliance { }
+
+export default PartiallyImplementedAppliance

--- a/src/interfaces/__test__/classes/index.js
+++ b/src/interfaces/__test__/classes/index.js
@@ -1,0 +1,2 @@
+export { default as FullyImplementedAppliance } from './FullyImplementedAppliance'
+export { default as PartiallyImplementedAppliance } from './PartiallyImplementedAppliance'

--- a/src/interfaces/index.js
+++ b/src/interfaces/index.js
@@ -1,0 +1,3 @@
+// Disabling because we intend to have more exports in the future.
+/* eslint-disable import/prefer-default-export */
+export { default as IAppliance } from './IAppliance'


### PR DESCRIPTION
## Description
This PR adds the `IAppliance` interface.  Since JavasScript doesn't actually support class abstraction and interface definition, we simulate these things by throwing errors if methods are not overridden by an appliance.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #2 
Relies on PR #4 since it is based off of it; be sure to merge that first and rebase before merging this.