### PR TITLE
Create data types constant file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 2
 [*.json]
 indent_style = space
 indent_size = 2
+
+[.eslintrc]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
   "rules": {
     "semi": [2, "never"],
     "indent": [2, "tab"],
-    "no-tabs": 0
+    "no-tabs": 0,
+    "import/named": 0
   },
   "env": {
     "es6": true,

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It is critical that great care be taken before adding code to this repository, s
 
 ## Included in this repository
 
+* `constants/dataTypes` - The data types that appliances can consume or produce.
 * `errors/*` - Errors that thrown by the interfaces defined in this repo.
 * `interfaces/*` - Interfaces used by the TV Kitchen.
 * `Payload.js` - A serializable payload used to communicate between appliances.

--- a/docs/DATA_TYPES.md
+++ b/docs/DATA_TYPES.md
@@ -1,0 +1,34 @@
+# TV Kitchen Data Types
+
+The [dataTypes.js](src/constants/dataTypes.js) constant file contains the list of standard types of data that the TV Kitchen and its appliances can produce.
+
+Someone creating a new appliance **is not bound to this list** and can invent new data types that their network of appliances might work with, it just won't be considered a standard data type unless it appears in this constants list.
+
+To suggest a new data type please open a [discussion issue](https://github.com/tvkitchen/base/issues/new?assignees=&labels=discussion&template=discussion.md) in the base repository.
+
+## Naming Data Types
+
+Data type constants have some naming (and value) rules.
+
+* Data type buckets must have an `ALL` attribute.
+* Data type bucket names can only consist of `A-Za-z0-9` and `_`.
+* Data type bucket names cannot be longer than 16 characters.
+* Data type constant names can only consist of `A-Za-z0-9` and `_`.
+* Data type constant names cannot be longer than 32 characters.
+* Data type constant values must match the following pattern: `{BUCKETNAME}.{CONSTANTNAME}`.
+
+## The Data Types
+
+### STREAM
+
+STREAM content is generally pulled from an Ingestion Engine and passed to the countertop.
+
+* `STREAM.ALL` - Any type of stream data.
+* `STREAM.DATA` - Buffers representing a portion of data stream.
+
+### TEXT
+* `TEXT.ALL` - Any type of text data.
+* `TEXT.ATOM` - The smallest possible chunk of text (e.g. a character, EOF, emoji).
+* `TEXT.WORD` - Complete, single words.
+* `TEXT.SENTENCE` - Complete sentences.
+* `TEXT.BLOB` - Arbitrary text of arbitrary length.

--- a/src/constants/__test__/dataTypes.test.js
+++ b/src/constants/__test__/dataTypes.test.js
@@ -1,0 +1,49 @@
+import { dataTypes } from '..'
+
+describe('dataTypes', () => {
+	describe('constant buckets', () => {
+		it('should be objects', () => {
+			Object.keys(dataTypes).forEach((bucketName) => {
+				expect(typeof dataTypes[bucketName]).toBe('object')
+			})
+		})
+		it('should be named according to bucket naming conventions', () => {
+			const validNamePattern = /[a-zA-Z0-9_]{1,16}/
+			Object.keys(dataTypes).forEach((bucketName) => {
+				expect(bucketName).toMatch(validNamePattern)
+			})
+		})
+		it('should have an `ANY` attribute', () => {
+			Object.keys(dataTypes).forEach((bucketName) => {
+				expect(dataTypes[bucketName]).toHaveProperty('ANY')
+			})
+		})
+	})
+
+	describe('constants', () => {
+		it('should be named according to constant naming conventions', () => {
+			const validNamePattern = /[a-zA-Z0-9_]{1,32}/
+			Object.keys(dataTypes).forEach((bucketName) => {
+				const bucket = dataTypes[bucketName]
+				const constantNames = Object.keys(bucket)
+				constantNames.forEach((constantName) => {
+					expect(constantName).toMatch(validNamePattern)
+				})
+			})
+		})
+	})
+
+	describe('constant values', () => {
+		it('should match constant bucket and name', () => {
+			Object.keys(dataTypes).forEach((bucketName) => {
+				const bucket = dataTypes[bucketName]
+				const constantNames = Object.keys(bucket)
+				constantNames.forEach((constantName) => {
+					const constantValue = bucket[constantName]
+					expect(typeof constantValue).toBe('string')
+					expect(constantValue).toBe(`${bucketName}.${constantName}`)
+				})
+			})
+		})
+	})
+})

--- a/src/constants/dataTypes.js
+++ b/src/constants/dataTypes.js
@@ -1,0 +1,12 @@
+export const STREAM = {
+	ANY: 'STREAM.ANY',
+	DATA: 'STREAM.DATA',
+}
+
+export const TEXT = {
+	ANY: 'TEXT.ANY',
+	ATOM: 'TEXT.ATOM',
+	WORD: 'TEXT.WORD',
+	SENTENCE: 'TEXT.SENTENCE',
+	BLOB: 'TEXT.BLOB',
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export * as dataTypes from './dataTypes'

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export * as constants from './constants'
 export * as errors from './errors'
 export * as interfaces from './interfaces'
 export { default as Payload } from './Payload'


### PR DESCRIPTION
## Description
This PR adds a list of data types which will be produced and consumed by appliances in the TV Kitchen.

It includes some tests that ensure the constants are named and populated according to standards -- these standards are part of the PR, so please feel free to push back on them if they don't feel right.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None.

## Related Issues
Resolves #7 

Related to PR #6 -- please do not merge this without merging that and rebasing.
