### PR TITLE
Rename stream container data type

### DIFF
--- a/docs/DATA_TYPES.md
+++ b/docs/DATA_TYPES.md
@@ -24,7 +24,7 @@ Data type constants have some naming (and value) rules.
 STREAM content is generally pulled from an Ingestion Engine and passed to the countertop.
 
 * `STREAM.ALL` - Any type of stream data.
-* `STREAM.DATA` - Buffers representing a portion of data stream.
+* `STREAM.CONTAINER` - Buffers representing a portion of an mpegts data stream.
 
 ### TEXT
 * `TEXT.ALL` - Any type of text data.

--- a/packages/constants/src/dataTypes.js
+++ b/packages/constants/src/dataTypes.js
@@ -1,6 +1,6 @@
 export const STREAM = {
 	ANY: 'STREAM.ANY',
-	DATA: 'STREAM.DATA',
+	CONTAINER: 'STREAM.CONTAINER',
 }
 
 export const TEXT = {


### PR DESCRIPTION
## Description
This PR changes the name of the `STREAM.DATA` to be slightly more specific.

There was some exploration of the concept of getting even more concrete
with something along the lines of `STREAM.CONTAINER.MPEGTS` but since we
are not planning to support other types of containers in the near future
this felt like it would be more likely wrong than right.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #14 
