### PR TITLE
Fix payload deserialization

### DIFF
--- a/packages/classes/src/Payload.js
+++ b/packages/classes/src/Payload.js
@@ -18,7 +18,8 @@ class Payload {
 
 	static deserialize = (serializedPayload) => {
 		const deserializedPayload = JSON.parse(serializedPayload, (key, value) => {
-			if (typeof value === 'object') {
+			if (typeof value === 'object'
+					&& value != null) {
 				const stringifiedType = value.type || ''
 				if (stringifiedType === 'Buffer') {
 					return Buffer.from(value.data || '')

--- a/packages/classes/src/__test__/Payload.test.js
+++ b/packages/classes/src/__test__/Payload.test.js
@@ -75,6 +75,11 @@ describe('Payload', () => {
 			const deserializedPayload = Payload.deserialize(serializedPayload)
 			expect(deserializedPayload).toMatchSnapshot()
 		})
+		it('should properly deserialize payload strings with null values', () => {
+			const serializedPayload = '{"data":"hello","type":null}'
+			const deserializedPayload = Payload.deserialize(serializedPayload)
+			expect(deserializedPayload).toMatchSnapshot()
+		})
 		it('should properly deserialize a serialized payload containing buffered data', () => {
 			const data = fs.readFileSync(path.join(__dirname, '/data/thinkingface.png'))
 			const parameters = {

--- a/packages/classes/src/__test__/__snapshots__/Payload.test.js.snap
+++ b/packages/classes/src/__test__/__snapshots__/Payload.test.js.snap
@@ -7,6 +7,13 @@ Payload {
 }
 `;
 
+exports[`Payload deserialize should properly deserialize payload strings with null values 1`] = `
+Payload {
+  "data": "hello",
+  "type": null,
+}
+`;
+
 exports[`Payload serialize should properly should serialize data with a fully populated object 1`] = `"{\\"data\\":\\"I ate all of the cheese\\",\\"type\\":\\"CONFESSION\\"}"`;
 
 exports[`Payload serialize should properly should serialize data with a partially populated object 1`] = `"{\\"data\\":\\"I ate all of the cheese\\",\\"type\\":null}"`;


### PR DESCRIPTION
## Description
This PR fixes a bug where the Payload deserializer would break on objects containing null values.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #18 