### PR TITLE
Prepare repo for publishing to npm

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,8 @@ If your PR fixes a bug or adds a feature, please write a test to go with the cha
 
 If you introduce a new framework or dependency, add the necessary information to [INSTALL.md](docs/INSTALL.md) and the other documentation.
 
+If appropriate, add a line describing your change to the package's CHANGELOG in the "Unreleased" section, nested under the appropriate header (such as "Added" or "Fixed"). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format, so please familiarize yourself with it!
+
 ### Configurations
 
 We're using `dotenv` for general runtime configuration settings. Never hard code values that should be configurable, but instead edit the .env.template file.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "bootstrap": "lerna bootstrap --use-workspaces",
     "build": "lerna exec --parallel -- babel --root-mode upward src -d lib",
     "lint": "eslint . --ext .js --ignore-pattern lib --ignore-pattern node_modules",
-    "prepublishOnly": "yarn lint && yarn test && yarn build",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn test && yarn lint",
+    "pretest": "yarn build",
     "test": "jest"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "jest"
   },
   "files": [
-    "dist/"
+    "lib/",
+    "src/"
   ],
   "workspaces": [
     "packages/*"

--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog for @tvkitchen/base-classes
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- Definition of the `Payload` class.
+- Initial setup.

--- a/packages/classes/README.md
+++ b/packages/classes/README.md
@@ -1,0 +1,19 @@
+# @tvkitchen/base-classes
+
+This package exports common classes used to communicate between TV Kitchen appliances.
+
+See the [@tvkitchen/base README](https://github.com/tvkitchen/base/blob/master/README.md) for more information.
+
+## Install
+
+Using Yarn:
+
+```sh
+yarn add @tvkitchen/base-classes --dev
+```
+
+or using npm:
+
+```sh
+npm install --save-dev @tvkitchen/base-classes
+```

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -6,6 +6,7 @@
     "url" : "https://github.com/tvkitchen/base.git",
     "directory": "packages/classes"
   },
+  "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tvkitchen/base-classes",
   "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/tvkitchen/base.git",
+    "directory": "packages/classes"
+  },
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-classes",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/constants/CHANGELOG.md
+++ b/packages/constants/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for @tvkitchen/base-constants
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- `STREAM.*` data types.
+- `TEXT.*` data types.
+- Initial setup.

--- a/packages/constants/README.md
+++ b/packages/constants/README.md
@@ -1,0 +1,19 @@
+# @tvkitchen/base-constants
+
+This package exports constant strings that define interfaces across the TV Kitchen project (e.g. types of data being passed around).
+
+See the [@tvkitchen/base README](https://github.com/tvkitchen/base/blob/master/README.md) for more information.
+
+## Install
+
+Using Yarn:
+
+```sh
+yarn add @tvkitchen/base-constants --dev
+```
+
+or using npm:
+
+```sh
+npm install --save-dev @tvkitchen/base-constants
+```

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -6,6 +6,7 @@
     "url" : "https://github.com/tvkitchen/base.git",
     "directory": "packages/constants"
   },
+  "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-constants",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tvkitchen/base-constants",
   "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/tvkitchen/base.git",
+    "directory": "packages/constants"
+  },
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog for @tvkitchen/base-errors
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- `NotImplementedError` error type.
+- `AbstractInstantiationError` error type.
+- `InterfaceInstantiationError` error type.
+- Initial setup.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,19 @@
+# @tvkitchen/base-errors
+
+This package exports common TV Kitchen error types.
+
+See the [@tvkitchen/base README](https://github.com/tvkitchen/base/blob/master/README.md) for more information.
+
+## Install
+
+Using Yarn:
+
+```sh
+yarn add @tvkitchen/base-errors --dev
+```
+
+or using npm:
+
+```sh
+npm install --save-dev @tvkitchen/base-errors
+```

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -6,6 +6,7 @@
     "url" : "https://github.com/tvkitchen/base.git",
     "directory": "packages/errors"
   },
+  "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tvkitchen/base-errors",
   "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/tvkitchen/base.git",
+    "directory": "packages/errors"
+  },
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-errors",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "module": "src/index.js"
 }

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog for @tvkitchen/base-interfaces
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- `IAppliance` core interface.
+- Initial setup.

--- a/packages/interfaces/README.md
+++ b/packages/interfaces/README.md
@@ -1,0 +1,19 @@
+# @tvkitchen/base-interfaces
+
+This package exports interfaces that define the shape of modular architectural components of TV Kitchen.
+
+See the [@tvkitchen/base README](https://github.com/tvkitchen/base/blob/master/README.md) for more information.
+
+## Install
+
+Using Yarn:
+
+```sh
+yarn add @tvkitchen/base-interfaces --dev
+```
+
+or using npm:
+
+```sh
+npm install --save-dev @tvkitchen/base-interfaces
+```

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-interfaces",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tvkitchen/base-interfaces",
   "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/tvkitchen/base.git",
+    "directory": "packages/interfaces"
+  },
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -6,6 +6,7 @@
     "url" : "https://github.com/tvkitchen/base.git",
     "directory": "packages/interfaces"
   },
+  "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Description
This PR prepares the repo for publishing to npm.

- Ensures we build the app before publishing
- Ensures we build the app before testing (which becomes redundant with the above, but is still safest)
- Reverts package version numbers to 0.0.0 so our first `lerna publish` process will work as expected
- Makes sure we publish both the original ES6 and transpiled files to npm
- Decorates each child package's `package.json` with repository and licensing info
- Adds a README for each child package (for completeness, and for rendering on npmjs.com)

Once this PR is merged into master, it should be safe to run `lerna publish` and away we go!

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Related Issues
Affects #13 but doesn't resolve it, since that will be a manual step
Relates to #11