### PR TITLE
Publish v1.0.0 of all packages

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.0.0 - 2020-05-27
+
 ### Added
 - Definition of the `Payload` class.
 - Initial setup.

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -8,5 +8,8 @@
   },
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "module": "src/index.js"
+  "module": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -2,8 +2,8 @@
   "name": "@tvkitchen/base-classes",
   "version": "0.0.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/tvkitchen/base.git",
+    "type": "git",
+    "url": "https://github.com/tvkitchen/base.git",
     "directory": "packages/classes"
   },
   "license": "Apache-2.0",

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-classes",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tvkitchen/base.git",

--- a/packages/constants/CHANGELOG.md
+++ b/packages/constants/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.0.0 - 2020-05-27
+
 ### Added
 - `STREAM.*` data types.
 - `TEXT.*` data types.

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,8 +2,8 @@
   "name": "@tvkitchen/base-constants",
   "version": "0.0.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/tvkitchen/base.git",
+    "type": "git",
+    "url": "https://github.com/tvkitchen/base.git",
     "directory": "packages/constants"
   },
   "license": "Apache-2.0",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -8,5 +8,8 @@
   },
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "module": "src/index.js"
+  "module": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-constants",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tvkitchen/base.git",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.0.0 - 2020-05-27
+
 ### Added
 - `NotImplementedError` error type.
 - `AbstractInstantiationError` error type.

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -8,5 +8,8 @@
   },
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "module": "src/index.js"
+  "module": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-errors",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tvkitchen/base.git",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -2,8 +2,8 @@
   "name": "@tvkitchen/base-errors",
   "version": "0.0.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/tvkitchen/base.git",
+    "type": "git",
+    "url": "https://github.com/tvkitchen/base.git",
     "directory": "packages/errors"
   },
   "license": "Apache-2.0",

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.0.0 - 2020-05-27
+
 ### Added
 - `IAppliance` core interface.
 - Initial setup.

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -2,8 +2,8 @@
   "name": "@tvkitchen/base-interfaces",
   "version": "0.0.0",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/tvkitchen/base.git",
+    "type": "git",
+    "url": "https://github.com/tvkitchen/base.git",
     "directory": "packages/interfaces"
   },
   "license": "Apache-2.0",

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -11,5 +11,8 @@
   "module": "src/index.js",
   "dependencies": {
     "@tvkitchen/base-errors": "*"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvkitchen/base-interfaces",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tvkitchen/base.git",
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/base-errors": "*"
+    "@tvkitchen/base-errors": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

In #13 we decided to publish directly to master (against my express advice, I'll note), which not only failed because of some missing settings, but had a series of [unforeseeable](https://www.youtube.com/watch?v=CJpQk6YAw1s) consequences. So, we're now moving safely to a branch to resolve pre-publishing issues and practice our first publish.

- Add the `publishConfig.access: "public"` setting to all packages; ensures our scoped packages are published as public
- Resolve some JSON formatting errors in package.json files
- Bumped version numbers to v1.0.0 and updated CHANGELOGs

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Related Issues
Affects #13