### PR TITLE
Remove references to Lerna bootstrapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 script:
   - npm run build
-  - npm run bootstrap
   - npm run lint
   - npm run test
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ We want to minimize universal coupling. Abstract implementations specific to an 
 
 ## Setting Up
 
-After installing project dependencies (`yarn install`) you will need to run:
+```sh
+yarn install
+```
 
-- `yarn build`
-- `yarn bootstrap`
-
-This will build and link sibling dependencies.
+This will install project dependencies, link local sibling dependencies (we're using [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/)), and build/transpile each package.
 
 ## About the TV Kitchen
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Bad Idea Factory <biffuddotcom@biffud.com>",
   "license": "Apache-2.0",
   "scripts": {
-    "bootstrap": "lerna bootstrap --use-workspaces",
     "build": "lerna exec --parallel -- babel --root-mode upward src -d lib",
     "lint": "eslint . --ext .js --ignore-pattern lib --ignore-pattern node_modules",
     "prepare": "yarn build",


### PR DESCRIPTION
## Description

When using native Yarn Worskpaces instead of Lerna’s own monorepo management, the Lerna devs recommend not using the `bootstrap` command, since it does nothing more than reach down to native `yarn install`.

This PR removes the bootstrap-related code and updates the documentation. It also removes the explicit `yarn build` command from the setup instructions, since that’s covered (it turns out) by our `prepare` script.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #21