### PR TITLE
Add descriptions to all package.json files

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Improved package description.
+
 ## 1.0.0 - 2020-05-27
 
 ### Added

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tvkitchen/base-classes",
+  "description": "Classes used for communication between TV Kitchen components.",
   "version": "1.0.0",
   "repository": {
     "type": "git",

--- a/packages/constants/CHANGELOG.md
+++ b/packages/constants/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Improved package description.
+
 ## 1.0.0 - 2020-05-27
 
 ### Added

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tvkitchen/base-constants",
+  "description": "Constants used for communication between TV Kitchen components.",
   "version": "1.0.0",
   "repository": {
     "type": "git",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Improved package description.
+
 ## 1.0.0 - 2020-05-27
 
 ### Added

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tvkitchen/base-errors",
+  "description": "Errors used by TV Kitchen components.",
   "version": "1.0.0",
   "repository": {
     "type": "git",

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Improved package description.
+
 ## 1.0.0 - 2020-05-27
 
 ### Added

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tvkitchen/base-interfaces",
+  "description": "Interfaces for modular components of the TV Kitchen.",
   "version": "1.0.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Without a description, the somewhat awkwardly-worded first line of each project’s README is used in summarizing the package on npmjs.com, which doesn’t put our best foot forward.

This PR adds thoughtfully-composed short descriptions instead.

## Due Diligence Checklist
- [ ] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
None

## Deploy Notes
None

## Related Issues
Resolves #28