### PR TITLE
Add Travis CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/tvkitchen/base.svg?branch=master)](https://travis-ci.com/tvkitchen/base)
+
 # TV Kitchen: Base
 
 This monorepo contains four base packages that are imported by various portions of the TV Kitchen:


### PR DESCRIPTION
## Description
This PR adds the Travis CI badge to our primary project README.

It really doesn't need review.

## Due Diligence Checklist
- [ ] Tests
- [ ] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
None.

## Deploy Notes
None.

## Related Issues
Resolves #31