### PR TITLE
Add “changelog updated” item to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 - [ ] Documentation
 - [ ] Consolidated commits
 - [ ] Relevant labels assigned
+- [ ] Changelog(s) updated
 
 ## Steps to Test
 1. `yarn test`


### PR DESCRIPTION
## Description
This PR updates our PR template to add a due diligence checklist item for updating the changelog. Which item is _not_ included below, since the PR is not merged, because that would be borrowing features from the future, which is not allowed.

## Due Diligence Checklist
- [ ] Tests
- [ ] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
None. Well, I suppose you could… well, no. There's no way to test it.

## Deploy Notes
None.

## Related Issues
Resolves #36