### PR TITLE
Add setup and teardown methods to IAppliance

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `setup` and `teardown` abstract methods to IAppliance.
+
 ## [1.0.1] - 2020-06-05
 
 ### Changed

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -46,6 +46,20 @@ class IAppliance {
 	}
 
 	/**
+	 * Prepares the Appliance to process data.
+	 */
+	setup = async () => {
+		throw new NotImplementedError('setup')
+	}
+
+	/**
+	 * Cleans up after processing is complete.
+	 */
+	teardown = async () => {
+		throw new NotImplementedError('teardown')
+	}
+
+	/**
 	 * Invokes the appliance on any unprocessed data in the appliance buffer.
 	 *
 	 * @return {Boolean} True if the appliance procesed data; False if the appliance needs more data.

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -53,6 +53,32 @@ describe('IAppliance', () => {
 		})
 	})
 
+	describe('setup', () => {
+		it('should throw an error when called without implementation', async () => {
+			const appliance = new PartiallyImplementedAppliance()
+			await expect(async () => appliance.setup())
+				.rejects.toBeInstanceOf(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', async () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.setup()).toBeDefined()
+		})
+	})
+
+	describe('teardown', () => {
+		it('should throw an error when called without implementation', async () => {
+			const appliance = new PartiallyImplementedAppliance()
+			await expect(async () => appliance.teardown())
+				.rejects.toBeInstanceOf(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', async () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.teardown()).toBeDefined()
+		})
+	})
+
 	describe('invoke', () => {
 		it('should throw an error when called without implementation', async () => {
 			const appliance = new PartiallyImplementedAppliance()

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -7,6 +7,10 @@ class FullyImplementedAppliance extends IAppliance {
 
 	isValidPayload = async () => true
 
+	setup = async () => null
+
+	teardown = async () => null
+
 	invoke = async () => true
 
 	ingestPayload = async () => true


### PR DESCRIPTION
## Description
This PR adds `setup` and `teardown` methods to the IAppliance interface.  These methods are intended to provide a way for Appliance authors to prepare the appliance for processing and clean up after processing without being forced to do so in the appliance constructor.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
No

## Related Issues
Resolves #41
