### PR TITLE
Update IAppliance invoke method

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- (MINOR): Modification of `invoke` (`IAppliance`) to consume a PayloadArray.
+- (MAJOR): Modification of `invoke` (`IAppliance`) to return a PayloadArray.
 
 ### Added
 - `setup` and `teardown` abstract methods to IAppliance.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -60,11 +60,15 @@ class IAppliance {
 	}
 
 	/**
-	 * Invokes the appliance on any unprocessed data in the appliance buffer.
+	 * Invokes the appliance on unprocessed data.
+	 * This generally should not be called directly, but rather Payloads should be passed to the
+	 * Appliance using the ingestPayload method.
 	 *
-	 * @return {Boolean} True if the appliance procesed data; False if the appliance needs more data.
+	 * @param {PayloadArray} payloads A PayloadArray containing Payloads that should be processed.
+	 * @return {PayloadArray}         Leftover Payloads that still need to be processed.
 	 */
-	invoke = async () => {
+	// eslint-disable-next-line no-unused-vars
+	invoke = async (payloads) => {
 		throw new NotImplementedError('invoke')
 	}
 


### PR DESCRIPTION
The previous definition of invoke put the burden of looking up the
Payloads that it would process on the method itself. Similarly, it
required the `invoke` method to manage the internal state (either
directly or via method calls) to register Payloads that would need to be
re-processed.

By updating the `invoke` API, we are suggesting that that management
should occur outside of the `invoke` logic itself. It will be passed the
Payloads that it is being asked to process, and it will return the
Payloads that were not processed but still warrant future processing.

The change to parameters should not impact anybody who implemented using
the old API, though it is recommended that all future implementations of
`invoke` avoid managing the Appliance's internal Payload state directly.

The change to the return value is a breaking change, since the previous
definition returned a Boolean, not a PayloadArray.

Issue #42

## Description
This PR adds a new parameter to `invoke` in `IAppliance` so that the method is directly passed the PayloadArray it is being expected to process.

This PR changes the return type of `invoke` as well, replacing the fairly pointless `Boolean` value with a `PayloadArray` of payloads that were not processed and should be re-submitted later.

These changes remove the burden of knowledge (and manipulation) of the Appliance's internal state management from `invoke`.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #42 
