### PR TITLE
Add logger to IAppliance

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `setup` and `teardown` abstract methods to IAppliance.
+- (MINOR): Added a logger to the IAppliance API.
 
 ## [1.0.1] - 2020-06-05
 

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
+    "@tvkitchen/base-constants": "^1.1.0",
     "@tvkitchen/base-errors": "^1.0.0"
   },
   "publishConfig": {

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -2,8 +2,22 @@ import {
 	InterfaceInstantiationError,
 	NotImplementedError,
 } from '@tvkitchen/base-errors'
+import {
+	logLevels,
+} from '@tvkitchen/base-constants'
 
 class IAppliance {
+	// A simple, replaceable logger for use by the Appliance.
+	logger = {
+		log: (level, message) => console.log(`${level}: ${message}`), // eslint-disable-line no-console
+		fatal: (message) => this.logger.log(logLevels.fatal, message),
+		error: (message) => this.logger.log(logLevels.error, message),
+		warn: (message) => this.logger.log(logLevels.warn, message),
+		info: (message) => this.logger.log(logLevels.info, message),
+		debug: (message) => this.logger.log(logLevels.debug, message),
+		trace: (message) => this.logger.log(logLevels.trace, message),
+	}
+
 	/**
 	 * Constructor for a new appliance.
 	 *

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -1,3 +1,6 @@
+// We test logging in this suite
+/* eslint-disable no-console */
+
 import {
 	InterfaceInstantiationError,
 	NotImplementedError,
@@ -25,6 +28,83 @@ describe('IAppliance', () => {
 			expect(() => {
 				new PartiallyImplementedAppliance() // eslint-disable-line no-new
 			}).not.toThrow(Error)
+		})
+	})
+
+	describe('logger', () => {
+		it('should be defined', () => {
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toBeDefined()
+		})
+		it('should support the log() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('log')
+			expect(typeof appliance.logger.log).toBe('function')
+			expect(() => appliance.logger.log('customLevel', 'Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the fatal() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('fatal')
+			expect(typeof appliance.logger.fatal).toBe('function')
+			expect(() => appliance.logger.fatal('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the error() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('error')
+			expect(typeof appliance.logger.error).toBe('function')
+			expect(() => appliance.logger.error('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the warn() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('warn')
+			expect(typeof appliance.logger.warn).toBe('function')
+			expect(() => appliance.logger.warn('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the info() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('info')
+			expect(typeof appliance.logger.info).toBe('function')
+			expect(() => appliance.logger.info('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the debug() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('debug')
+			expect(typeof appliance.logger.debug).toBe('function')
+			expect(() => appliance.logger.debug('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
+		})
+		it('should support the trace() method', () => {
+			const consoleLogCopy = console.log
+			console.log = jest.fn()
+			const appliance = new PartiallyImplementedAppliance()
+			expect(appliance.logger).toHaveProperty('trace')
+			expect(typeof appliance.logger.trace).toBe('function')
+			expect(() => appliance.logger.trace('Test message')).not.toThrow()
+			expect(console.log).toHaveBeenCalledTimes(1)
+			console.log = consoleLogCopy
 		})
 	})
 


### PR DESCRIPTION
Appliances are going to need to be able to log things, especially as we
work towards the concept of a method that verifies if an Appliance has
dependencies properly installed and outputs resolution instructions.

This adds a logger with an API that will work with
a [winston](https://www.npmjs.com/package/winston)  object.

Appliance developers should not assume that logger has been replaced,
and should only call the methods that are officially supported in the
IAppliance documentation.

Issue #48

## Description
This PR adds a default logger to IAppliance, which will allow Appliance developers to appropriately log in a way that can be collected by the TVKitchen.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #48 

Related to #47 
