### PR TITLE
Add log level constants

### DIFF
--- a/packages/constants/CHANGELOG.md
+++ b/packages/constants/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- (MINOR) Added log level constants.
 
 ## [1.0.1] - 2020-06-05
 

--- a/packages/constants/docs/LOG_LEVELS.md
+++ b/packages/constants/docs/LOG_LEVELS.md
@@ -1,0 +1,18 @@
+# Log Levels
+
+In order to promote consistent logging across the TV Kitchen ecosystem, the following log levels should be used as described when logging:
+
+- **fatal:** Any error that is forcing a shutdown of the service or application to prevent data loss (or further data loss). Reserve these only for the most heinous errors and situations where there is guaranteed to have been data corruption or loss.
+
+- **error:** Any error which is fatal to the operation, but not the service or application (can't open a required file, missing data, etc.). These errors will force user (administrator, or direct user) intervention. These are usually reserved for incorrect connection strings, missing services, etc.
+
+- **warn:** Anything that can potentially cause application oddities, but for which you are automatically recovering. (Such as switching from a primary to backup server, retrying an operation, missing secondary data, etc.)
+
+- **info:** Generally useful information to log (service start/stop, configuration assumptions, etc). Info that one should always have available but usually won't be relevant under normal circumstances. This is the out-of-the-box config level.
+
+- **debug:** Information that is diagnostically helpful to people more than just developers (IT, sysadmins, etc.).
+
+- **trace:** Used only for "tracing" the code and trying to find one part of a function specifically.
+
+
+*These levels and descriptions borrowed and slightly modified [from this StackOverflow answer](https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels)*

--- a/packages/constants/src/__test__/logLevels.test.js
+++ b/packages/constants/src/__test__/logLevels.test.js
@@ -1,0 +1,16 @@
+import { logLevels } from '..'
+
+describe('logLevels', () => {
+	describe('entries', () => {
+		it('should be camelCase', () => {
+			Object.keys(logLevels).forEach((logLevel) => {
+				expect(logLevel).toMatch(/^[a-z][a-zA-Z]*$/)
+			})
+		})
+		it('should have a value that matches the constant name', () => {
+			Object.keys(logLevels).forEach((logLevel) => {
+				expect(logLevels[logLevel]).toEqual(logLevel)
+			})
+		})
+	})
+})

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -1,1 +1,2 @@
 export * as dataTypes from './dataTypes'
+export * as logLevels from './logLevels'

--- a/packages/constants/src/logLevels.js
+++ b/packages/constants/src/logLevels.js
@@ -1,0 +1,7 @@
+// Note: Winston log levels are camelCase, so we match that here
+export const fatal = 'fatal'
+export const error = 'error'
+export const warn = 'warn'
+export const info = 'info'
+export const debug = 'debug'
+export const trace = 'trace'


### PR DESCRIPTION
As we seek to have consistant logging across the application, these log
levels should make it easier for Appliance developers to log
appropriately.

Issue #50

## Description
This PR adds log level constants for use in other parts of the system when logging.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #50 