### PR TITLE
Make audit an async method

### DIFF
--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -38,7 +38,7 @@ class IAppliance {
 	 *
 	 * @return {Boolean} Whether the dependencies and configurations properly exist.
 	 */
-	audit = () => {
+	audit = async () => {
 		throw new NotImplementedError('audit')
 	}
 

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -109,14 +109,15 @@ describe('IAppliance', () => {
 	})
 
 	describe('audit', () => {
-		it('should throw an error when called without implementation', () => {
+		it('should throw an error when called without implementation', async () => {
 			const appliance = new PartiallyImplementedAppliance()
-			expect(() => appliance.audit()).toThrow(NotImplementedError)
+			await expect(async () => appliance.audit())
+				.rejects.toBeInstanceOf(NotImplementedError)
 		})
 
-		it('should not throw an error when called with implementation', () => {
+		it('should not throw an error when called with implementation', async () => {
 			const appliance = new FullyImplementedAppliance()
-			expect(() => appliance.audit()).not.toThrow(NotImplementedError)
+			expect(await appliance.audit()).toBeDefined()
 		})
 	})
 

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -1,7 +1,7 @@
 import IAppliance from '../../IAppliance'
 
 class FullyImplementedAppliance extends IAppliance {
-	audit = () => true
+	audit = async () => true
 
 	getInputTypes = () => []
 


### PR DESCRIPTION
## Description
This PR changes `audit` to be an async method, which was a mistake in the original PR for that method.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #55
