### PR TITLE
Add Payload and PayloadArray ducktypes

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A static `isPayload` method to the `Payload` class.
 
 ## [1.2.1] - 2020-06-23
 Re-release of [1.2.0] due to accidental unpublishing.

--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - A static `isPayload` method to the `Payload` class.
+- A static `isPayloadArray` method to the `PayloadArray` class.
+
+### Changed
+- Update `PayloadArray` to use the `isPayload` method for validation.
 
 ## [1.2.1] - 2020-06-23
 Re-release of [1.2.0] due to accidental unpublishing.

--- a/packages/classes/src/Payload.js
+++ b/packages/classes/src/Payload.js
@@ -41,6 +41,30 @@ class Payload {
 		})
 		return new Payload(deserializedPayload)
 	}
+
+	/**
+	 * A comprehensive list of attributes that an object must have to be considered a Payload.
+	 *
+	 * This attribute is INTERNAL and should not be relied on; it may be removed and only exists
+	 * as an optimization to the isPayload method.
+	 *
+	 * @type {Array}
+	 */
+	static duckTypeProperties = Object.getOwnPropertyNames(new Payload())
+
+	/**
+	 * Checks whether an object is an instance of a Payload.
+	 *
+	 * This uses duck typing, rather than instanceof, since we can't rely on the prototype chain
+	 * matching across packages and versions.
+	 *
+	 * @param  {Object}  obj The object being tested.
+	 * @return {Boolean}     The result of the duck test.
+	 */
+	static isPayload = (obj) => (
+		Payload.duckTypeProperties
+			.every((property) => Object.prototype.hasOwnProperty.call(obj, property))
+	)
 }
 
 export default Payload

--- a/packages/classes/src/PayloadArray.js
+++ b/packages/classes/src/PayloadArray.js
@@ -21,7 +21,7 @@ class PayloadArray {
 	 * @return {PayloadArray}    This PayloadArray to allow for chaining.
 	 */
 	insert = (payload) => {
-		if (!(payload instanceof Payload)) {
+		if (!Payload.isPayload(payload)) {
 			throw new Error('Attempt to insert a non-Payload to PayloadArray')
 		}
 		const index = this.indexOfPosition(payload.position)
@@ -80,6 +80,30 @@ class PayloadArray {
 	 * @return {Array} The resulting Array.
 	 */
 	toArray = () => [...this.payloads]
+
+	/**
+	 * A comprehensive list of attributes that an object must have to be considered a PayloadArray.
+	 *
+	 * This attribute is INTERNAL and should not be relied on; it may be removed and only exists
+	 * as an optimization to the isPayloadArray method.
+	 *
+	 * @type {Array}
+	 */
+	static duckTypeProperties = Object.getOwnPropertyNames(new PayloadArray())
+
+	/**
+	 * Checks whether an object is an instance of a PayloadArray.
+	 *
+	 * This uses duck typing, rather than instanceof, since we can't rely on the prototype chain
+	 * matching across packages and versions.
+	 *
+	 * @param  {Object} obj The object being tested.
+	 * @return {Boolean}     The result of the duck test.
+	 */
+	static isPayloadArray = (obj) => (
+		PayloadArray.duckTypeProperties
+			.every((property) => Object.prototype.hasOwnProperty.call(obj, property))
+	)
 }
 
 export default PayloadArray

--- a/packages/classes/src/__test__/Payload.unit.test.js
+++ b/packages/classes/src/__test__/Payload.unit.test.js
@@ -108,4 +108,32 @@ describe('Payload', () => {
 			expect(deserializedPayload).toEqual(payload)
 		})
 	})
+
+	describe('duckTypeProperties', () => {
+		it('should contain all properties of a Payload', () => {
+			const completePropertySet = new Set([
+				...Payload.duckTypeProperties,
+				...Object.getOwnPropertyNames(new Payload()),
+			])
+			expect(completePropertySet.size).toEqual(Payload.duckTypeProperties.length)
+		})
+	})
+
+	describe('isPayload', () => {
+		it('should properly detect a Payload object', () => {
+			const payload = new Payload()
+			expect(Payload.isPayload(payload)).toBe(true)
+		})
+		it('should properly detect a non-Payload object', () => {
+			const obj = {}
+			expect(Payload.isPayload(obj)).toBe(false)
+		})
+		it('should properly detect a non-Payload object with common fields', () => {
+			const obj = {
+				data: 'sup',
+				type: 'hello',
+			}
+			expect(Payload.isPayload(obj)).toBe(false)
+		})
+	})
 })

--- a/packages/classes/src/__test__/PayloadArray.unit.test.js
+++ b/packages/classes/src/__test__/PayloadArray.unit.test.js
@@ -172,4 +172,32 @@ describe('PayloadArray', () => {
 			expect(payloadArray.toArray()).not.toEqual(['pants'])
 		})
 	})
+
+	describe('duckTypeProperties', () => {
+		it('should contain all properties of a PayloadArray', () => {
+			const completePropertySet = new Set([
+				...PayloadArray.duckTypeProperties,
+				...Object.getOwnPropertyNames(new PayloadArray()),
+			])
+			expect(completePropertySet.size).toEqual(PayloadArray.duckTypeProperties.length)
+		})
+	})
+
+	describe('isPayloadArray', () => {
+		it('should properly detect a PayloadArray object', () => {
+			const payloadArray = new PayloadArray()
+			expect(PayloadArray.isPayloadArray(payloadArray)).toBe(true)
+		})
+		it('should properly detect a non-PayloadArray object', () => {
+			const obj = {}
+			expect(PayloadArray.isPayloadArray(obj)).toBe(false)
+		})
+		it('should properly detect a non-PayloadArray object with common fields', () => {
+			const obj = {
+				length: 15,
+				insert: () => true,
+			}
+			expect(PayloadArray.isPayloadArray(obj)).toBe(false)
+		})
+	})
 })


### PR DESCRIPTION
## Description
This PR adds static duck typing methods to the Payload and PayloadArray methods, which should help in cases where `instanceof` is unreliable.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- None

## Related Issues
Resolves #60 
