### PR TITLE
Add IAppliance duck typing

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the minimum version of `@tvkitchen/base-constants` to `1.1.1`.
 
+### Added
+- Create `isIAppliance` duck type method to IAppliance.
+
 ## [3.0.0] - 2020-06-23
 ### Changed
 - `audit` method turned to an async method.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -1,3 +1,7 @@
+// We need to allow a second class in this file that is used for duck typing.
+// It will never be referecned, and is defined within the duck typing method.
+/* eslint-disable max-classes-per-file */
+
 import {
 	InterfaceInstantiationError,
 	NotImplementedError,
@@ -135,6 +139,37 @@ class IAppliance {
 	emitResult = (payload) => {
 		throw new NotImplementedError('emitResult')
 	}
+
+	/**
+	 * A comprehensive list of attributes that an object must have to be considered an IAppliance.
+	 *
+	 * This attribute is INTERNAL and should not be relied on; it may be removed and only exists
+	 * as an optimization to the isIAppliance method.
+	 *
+	 * @type {Array}
+	 */
+	static duckTypeProperties = (() => {
+		class Appliance extends IAppliance {} // Since IAppliance cannot be instantiated directly.
+		return Object.getOwnPropertyNames(new Appliance())
+	})()
+
+	/**
+	 * Checks whether an object is an instance of an IAppliance.
+	 *
+	 * This uses duck typing, rather than instanceof, since we can't rely on the prototype chain
+	 * matching across packages and versions.
+	 *
+	 * This method is implemented, which violates the spirit of interfaces.
+	 * Luckily, JavaScript doesn't actually know what an interface is. Also if it handled typing
+	 * in a reasonable way we wouldn't have to do this to begin with.
+	 *
+	 * @param  {Object} obj The object being tested.
+	 * @return {Boolean}     The result of the duck test.
+	 */
+	static isIAppliance = (obj) => (
+		IAppliance.duckTypeProperties
+			.every((property) => Object.prototype.hasOwnProperty.call(obj, property))
+	)
 }
 
 export default IAppliance

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -233,4 +233,31 @@ describe('IAppliance', () => {
 			expect(() => appliance.emitResult()).not.toThrow(NotImplementedError)
 		})
 	})
+
+	describe('duckTypeProperties', () => {
+		it('should contain all properties of an IAppliance', () => {
+			const completePropertySet = new Set([
+				...IAppliance.duckTypeProperties,
+				...Object.getOwnPropertyNames(new FullyImplementedAppliance()),
+			])
+			expect(completePropertySet.size).toEqual(IAppliance.duckTypeProperties.length)
+		})
+	})
+
+	describe('isIAppliance', () => {
+		it('should properly detect an IAppliance object', () => {
+			const appliance = new FullyImplementedAppliance()
+			expect(IAppliance.isIAppliance(appliance)).toBe(true)
+		})
+		it('should properly detect a non-IAppliance object', () => {
+			const obj = {}
+			expect(IAppliance.isIAppliance(obj)).toBe(false)
+		})
+		it('should properly detect a non-IAppliance object with common fields', () => {
+			const obj = {
+				audit: () => true,
+			}
+			expect(IAppliance.isIAppliance(obj)).toBe(false)
+		})
+	})
 })


### PR DESCRIPTION
## Description
This PR adds an IAppliance ducktype method, which makes it possible to determine if an object is an instance of `IAppliance` without relying on `instanceof`.

Note that since we cannot instantiate IAppliance directly, we had to create a helper "class" in order to use our getOwnPropertyNames short cut.  The alternative was to allow a special flag such as
`allowInterfaceInstantiation` that could be passed in as an overrideSetting, but I preferred the isolated code smell to something that would actually impact the API of IAppliance.


## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #57
