### PR TITLE
Update Payload createdAt default value

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update `PayloadArray` to use the `isPayload` method for validation.
+- Update the default value for Payload's `createdAt` to be the current time.
 
 ## [1.2.1] - 2020-06-23
 Re-release of [1.2.0] due to accidental unpublishing.

--- a/packages/classes/src/Payload.js
+++ b/packages/classes/src/Payload.js
@@ -8,6 +8,12 @@ const defaults = {
 }
 
 class Payload {
+	/**
+	 * Creates a new Payload.
+	 * If createdAt is not specified, it defaults to the current time.
+	 *
+	 * @param  {Object} properties Allow specification of properties on construction.
+	 */
 	constructor({
 		data = defaults.data,
 		type = defaults.type,
@@ -19,7 +25,7 @@ class Payload {
 		Object.assign(this, {
 			data,
 			type,
-			createdAt,
+			createdAt: createdAt || (new Date()).toISOString(),
 			timestamp,
 			duration,
 			position,

--- a/packages/classes/src/__test__/Payload.unit.test.js
+++ b/packages/classes/src/__test__/Payload.unit.test.js
@@ -35,17 +35,38 @@ describe('Payload', () => {
 			expect(payload.duration).toBe(1000)
 			expect(payload.position).toBe(60000)
 		})
+		it('should populate a default createdAt', () => {
+			const payload = new Payload()
+			expect(payload.createdAt).not.toBe('')
+		})
+		it('should set createdAt differently for payloads created at different times', () => {
+			jest.clearAllMocks()
+			const firstMockDate = new Date(1592156234000)
+			jest.spyOn(global, 'Date').mockImplementation(() => firstMockDate)
+			const firstPayload = new Payload()
+			jest.spyOn(global, 'Date').mockRestore()
+			const secondMockDate = new Date(1592156235000)
+			jest.spyOn(global, 'Date').mockImplementation(() => secondMockDate)
+			const secondPayload = new Payload()
+			jest.spyOn(global, 'Date').mockRestore()
+			expect(firstPayload.createdAt).not.toEqual(secondPayload.createdAt)
+		})
 	})
 
 	describe('serialize', () => {
 		it('should properly should serialize data with an empty object', () => {
+			jest.clearAllMocks()
+			const mockDate = new Date(1592156234000)
+			jest.spyOn(global, 'Date').mockImplementation(() => mockDate)
 			const payload = new Payload()
+			jest.spyOn(global, 'Date').mockRestore()
 			const serializedPayload = Payload.serialize(payload)
 			expect(serializedPayload).toMatchSnapshot()
 		})
 		it('should properly should serialize data with a partially populated object', () => {
 			const parameters = {
 				data: 'I ate all of the cheese',
+				createdAt: '2020-07-08T17:28:29.032Z',
 			}
 			const payload = new Payload(parameters)
 			const serializedPayload = Payload.serialize(payload)
@@ -94,7 +115,9 @@ describe('Payload', () => {
 		it('should properly deserialize payload strings with null values', () => {
 			const serializedPayload = '{"data":"hello","type":null}'
 			const deserializedPayload = Payload.deserialize(serializedPayload)
-			expect(deserializedPayload).toMatchSnapshot()
+			expect(deserializedPayload).toMatchSnapshot({
+				createdAt: expect.any(String),
+			})
 		})
 		it('should properly deserialize a serialized payload containing buffered data', () => {
 			const data = fs.readFileSync(path.join(__dirname, '/data/thinkingface.png'))

--- a/packages/classes/src/__test__/__snapshots__/Payload.unit.test.js.snap
+++ b/packages/classes/src/__test__/__snapshots__/Payload.unit.test.js.snap
@@ -12,8 +12,8 @@ Payload {
 `;
 
 exports[`Payload deserialize should properly deserialize payload strings with null values 1`] = `
-Payload {
-  "createdAt": "",
+Object {
+  "createdAt": Any<String>,
   "data": "hello",
   "duration": 0,
   "position": 0,
@@ -24,6 +24,6 @@ Payload {
 
 exports[`Payload serialize should properly should serialize data with a fully populated object 1`] = `"{\\"data\\":\\"I ate all of the cheese\\",\\"type\\":\\"CONFESSION\\",\\"createdAt\\":\\"2020-02-02T03:04:05.000Z\\",\\"timestamp\\":\\"2020-02-02T03:04:01.000Z\\",\\"duration\\":1000,\\"position\\":60000}"`;
 
-exports[`Payload serialize should properly should serialize data with a partially populated object 1`] = `"{\\"data\\":\\"I ate all of the cheese\\",\\"type\\":null,\\"createdAt\\":\\"\\",\\"timestamp\\":\\"\\",\\"duration\\":0,\\"position\\":0}"`;
+exports[`Payload serialize should properly should serialize data with a partially populated object 1`] = `"{\\"data\\":\\"I ate all of the cheese\\",\\"type\\":null,\\"createdAt\\":\\"2020-07-08T17:28:29.032Z\\",\\"timestamp\\":\\"\\",\\"duration\\":0,\\"position\\":0}"`;
 
-exports[`Payload serialize should properly should serialize data with an empty object 1`] = `"{\\"data\\":null,\\"type\\":null,\\"createdAt\\":\\"\\",\\"timestamp\\":\\"\\",\\"duration\\":0,\\"position\\":0}"`;
+exports[`Payload serialize should properly should serialize data with an empty object 1`] = `"{\\"data\\":null,\\"type\\":null,\\"createdAt\\":\\"2020-06-14T17:37:14.000Z\\",\\"timestamp\\":\\"\\",\\"duration\\":0,\\"position\\":0}"`;


### PR DESCRIPTION
## Description
This PR changes the default value of `createdAt` for new `Payload` objects so that it is set to whatever the current time's ISO string is at the time of construction.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #62 