### PR TITLE
Add appliance event constants

### DIFF
--- a/packages/constants/CHANGELOG.md
+++ b/packages/constants/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added appliance event constants.
 
 ## [1.1.1] - 2020-06-29
 ### Added

--- a/packages/constants/docs/APPLIANCE_EVENTS.md
+++ b/packages/constants/docs/APPLIANCE_EVENTS.md
@@ -1,0 +1,10 @@
+# Appliance Events
+
+The following events will be emitted by `IAppliance` instances:
+
+* **'starting'**: Emitted when the appliance has been told to start.
+* **'ready'**: Emitted when the appliance is ready to start invoking on new data.
+* **'error'**: Emitted when the appliance has faced a problem. Event includes the error.
+* **'payload'**: Emitted when the appliance has created a new payload. Event includes the payload.
+* **'stopping'**: Emitted when the appliance has been told to shut down.
+* **'stopped'**: Emitted when the appliance has finished shutting down.

--- a/packages/constants/src/__test__/applianceEvents.test.js
+++ b/packages/constants/src/__test__/applianceEvents.test.js
@@ -1,0 +1,12 @@
+import { applianceEvents } from '..'
+
+describe('applianceEvents', () => {
+	describe('constants', () => {
+		it('should have capitalized names', () => {
+			const validNamePattern = /[A-Z_]{1,32}/
+			Object.keys(applianceEvents).forEach((constantName) => {
+				expect(constantName).toMatch(validNamePattern)
+			})
+		})
+	})
+})

--- a/packages/constants/src/applianceEvents.js
+++ b/packages/constants/src/applianceEvents.js
@@ -1,0 +1,6 @@
+export const STARTING = 'starting'
+export const READY = 'ready'
+export const ERROR = 'error'
+export const PAYLOAD = 'payload'
+export const STOPPING = 'stopping'
+export const STOPPED = 'stopped'

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -1,2 +1,3 @@
 export * as dataTypes from './dataTypes'
 export * as logLevels from './logLevels'
+export * as applianceEvents from './applianceEvents'


### PR DESCRIPTION
## Description
This PR adds appliance event constants, which will be used by appliance implementations to send events in addition to being used by the TV Kitchen to handle those events.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #65
