### PR TITLE
Default to silent tests

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -8,5 +8,6 @@
       "statements": 100
     }
   },
-  "testPathIgnorePatterns": ["<rootDir>/packages/(?:.+?)/lib/"]
+  "testPathIgnorePatterns": ["<rootDir>/packages/(?:.+?)/lib/"],
+  "silent": true
 }


### PR DESCRIPTION
Issue #53

## Description
This PR adds the `silent: true` option to the jest config.  Anybody who wants debug / console output when running tests can always use Jest's `--no-silent` flag when testing:

`yarn test --no-silent`

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. add a console.log or something to a test
2. `yarn test`
3 `yarn test --no-silent`


## Deploy Notes
N/A

## Related Issues
Resolves #53
