### PR TITLE
Remove emitResult from IAppliance

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated the minimum version of `@tvkitchen/base-constants` to `1.1.1`.
+- Removed the unnecessarily required `emitResult` method from `IAppliance`.
 
 ### Added
 - Create `isIAppliance` duck type method to IAppliance.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -130,17 +130,6 @@ class IAppliance {
 	}
 
 	/**
-	 * Called by an implemented appliance when there is data worth sharing.
-	 *
-	 * @param  {Payload} payload The result that is ready to share.
-	 * @return {Boolean}         Returns true if there are output listeners, false otherwise.
-	 */
-	// eslint-disable-next-line no-unused-vars
-	emitResult = (payload) => {
-		throw new NotImplementedError('emitResult')
-	}
-
-	/**
 	 * A comprehensive list of attributes that an object must have to be considered an IAppliance.
 	 *
 	 * This attribute is INTERNAL and should not be relied on; it may be removed and only exists

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -222,18 +222,6 @@ describe('IAppliance', () => {
 		})
 	})
 
-	describe('emitResult', () => {
-		it('should throw an error when called without implementation', () => {
-			const appliance = new PartiallyImplementedAppliance()
-			expect(() => appliance.emitResult()).toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when called with implementation', () => {
-			const appliance = new FullyImplementedAppliance()
-			expect(() => appliance.emitResult()).not.toThrow(NotImplementedError)
-		})
-	})
-
 	describe('duckTypeProperties', () => {
 		it('should contain all properties of an IAppliance', () => {
 			const completePropertySet = new Set([

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -18,8 +18,6 @@ class FullyImplementedAppliance extends IAppliance {
 	ingestPayload = async () => true
 
 	on = () => true
-
-	emitResult = () => true
 }
 
 export default FullyImplementedAppliance


### PR DESCRIPTION
## Description
This PR removes the implementation-level `emitResult` method from `IAppliance`.

`emitResult` was always documented as an internal helper method, but since IAppliance did not actually use it, it did not belong at the interface level.

IAppliance should really only be defining the external API -- for anybody *using* an Appliance. `emitResult` was a method for an Appliance implementor, which means it belongs in `AbstractAppliance` instead.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #67
