### PR TITLE
Convert type lookup methods to static methods

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the minimum version of `@tvkitchen/base-constants` to `1.1.1`.
 - Removed the unnecessarily required `emitResult` method from `IAppliance`.
+- Made the `IAppliance` `getInputTypes` and `getOutputTypes` methods static.
 
 ### Added
 - Create `isIAppliance` duck type method to IAppliance.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -47,24 +47,6 @@ class IAppliance {
 	}
 
 	/**
-	 * Getter for the list of data types accepted by the appliance.
-	 *
-	 * @return {String[]} The list of data types accepted by the appliance.
-	 */
-	getInputTypes = () => {
-		throw new NotImplementedError('getInputTypes')
-	}
-
-	/**
-	 * Getter for the list of data types produced by the appliance.
-	 *
-	 * @return {String[]} The list of data types produced by the appliance.
-	 */
-	getOutputTypes = () => {
-		throw new NotImplementedError('getOutputTypes')
-	}
-
-	/**
 	 * Asserts that a given payload is actually a payload.
    *
 	 * @param  {Payload} payload The payload that we want to validate.
@@ -159,6 +141,24 @@ class IAppliance {
 		IAppliance.duckTypeProperties
 			.every((property) => Object.prototype.hasOwnProperty.call(obj, property))
 	)
+
+	/**
+	 * Getter for the list of data types accepted by the appliance.
+	 *
+	 * @return {String[]} The list of data types accepted by the appliance.
+	 */
+	static getInputTypes = () => {
+		throw new NotImplementedError('getInputTypes')
+	}
+
+	/**
+	 * Getter for the list of data types produced by the appliance.
+	 *
+	 * @return {String[]} The list of data types produced by the appliance.
+	 */
+	static getOutputTypes = () => {
+		throw new NotImplementedError('getOutputTypes')
+	}
 }
 
 export default IAppliance

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -19,11 +19,6 @@ describe('IAppliance', () => {
 			}).toThrow(InterfaceInstantiationError)
 		})
 
-		it('should throw an error when getInputTypes() is called without implementation', () => {
-			const implementedAppliance = new PartiallyImplementedAppliance()
-			expect(() => implementedAppliance.getInputTypes()).toThrow(NotImplementedError)
-		})
-
 		it('should allow construction when extended', () => {
 			expect(() => {
 				new PartiallyImplementedAppliance() // eslint-disable-line no-new
@@ -121,18 +116,6 @@ describe('IAppliance', () => {
 		})
 	})
 
-	describe('getOutputTypes', () => {
-		it('should throw an error when called without implementation', () => {
-			const appliance = new PartiallyImplementedAppliance()
-			expect(() => appliance.getOutputTypes()).toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when called with implementation', () => {
-			const appliance = new FullyImplementedAppliance()
-			expect(() => appliance.getOutputTypes()).not.toThrow(NotImplementedError)
-		})
-	})
-
 	describe('isValidPayload', () => {
 		it('should throw an error when called without implementation', async () => {
 			const appliance = new PartiallyImplementedAppliance()
@@ -198,18 +181,6 @@ describe('IAppliance', () => {
 		})
 	})
 
-	describe('getInputTypes', () => {
-		it('should throw an error when called without implementation', () => {
-			const appliance = new PartiallyImplementedAppliance()
-			expect(() => appliance.getInputTypes()).toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when called with implementation', () => {
-			const appliance = new FullyImplementedAppliance()
-			expect(() => appliance.getInputTypes()).not.toThrow(NotImplementedError)
-		})
-	})
-
 	describe('on', () => {
 		it('should throw an error when called without implementation', () => {
 			const appliance = new PartiallyImplementedAppliance()
@@ -246,6 +217,26 @@ describe('IAppliance', () => {
 				audit: () => true,
 			}
 			expect(IAppliance.isIAppliance(obj)).toBe(false)
+		})
+	})
+
+	describe('getInputTypes', () => {
+		it('should throw an error when called without implementation', () => {
+			expect(() => PartiallyImplementedAppliance.getInputTypes()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			expect(() => FullyImplementedAppliance.getInputTypes()).not.toThrow(NotImplementedError)
+		})
+	})
+
+	describe('getOutputTypes', () => {
+		it('should throw an error when called without implementation', () => {
+			expect(() => PartiallyImplementedAppliance.getOutputTypes()).toThrow(NotImplementedError)
+		})
+
+		it('should not throw an error when called with implementation', () => {
+			expect(() => FullyImplementedAppliance.getOutputTypes()).not.toThrow(NotImplementedError)
 		})
 	})
 })

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -3,10 +3,6 @@ import IAppliance from '../../IAppliance'
 class FullyImplementedAppliance extends IAppliance {
 	audit = async () => true
 
-	getInputTypes = () => []
-
-	getOutputTypes = () => []
-
 	isValidPayload = async () => true
 
 	setup = async () => null
@@ -18,6 +14,10 @@ class FullyImplementedAppliance extends IAppliance {
 	ingestPayload = async () => true
 
 	on = () => true
+
+	static getInputTypes = () => []
+
+	static getOutputTypes = () => []
 }
 
 export default FullyImplementedAppliance


### PR DESCRIPTION
## Description
This PR converts the getInputType and getOutputType methods of IAppliance were originally
defined as being instance methods.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #77
