### PR TITLE
Rename IAppliance setup / teardown

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Renamed `setup` to `start` and changed its return type.
+- Renamed `teardown` to `stop` and changed its return type.
 
 ## [4.0.0-alpha.1]
 ### Changed

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -58,17 +58,21 @@ class IAppliance {
 	}
 
 	/**
-	 * Prepares the Appliance to process data.
+	 * Prepares the Appliance to process data and starts data processing.
+	 *
+	 * @return {Boolean} Whether the appliance successfully started.
 	 */
-	setup = async () => {
-		throw new NotImplementedError('setup')
+	start = async () => {
+		throw new NotImplementedError('start')
 	}
 
 	/**
-	 * Cleans up after processing is complete.
+	 * Stops the appliance from processing data and cleans up the appliance.
+	 *
+	 * @return {Boolean} Whether the appliance successfully stopped.
 	 */
-	teardown = async () => {
-		throw new NotImplementedError('teardown')
+	stop = async () => {
+		throw new NotImplementedError('stop')
 	}
 
 	/**

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -129,29 +129,29 @@ describe('IAppliance', () => {
 		})
 	})
 
-	describe('setup', () => {
+	describe('start', () => {
 		it('should throw an error when called without implementation', async () => {
 			const appliance = new PartiallyImplementedAppliance()
-			await expect(async () => appliance.setup())
+			await expect(async () => appliance.start())
 				.rejects.toBeInstanceOf(NotImplementedError)
 		})
 
 		it('should not throw an error when called with implementation', async () => {
 			const appliance = new FullyImplementedAppliance()
-			expect(await appliance.setup()).toBeDefined()
+			expect(await appliance.start()).toBeDefined()
 		})
 	})
 
-	describe('teardown', () => {
+	describe('stop', () => {
 		it('should throw an error when called without implementation', async () => {
 			const appliance = new PartiallyImplementedAppliance()
-			await expect(async () => appliance.teardown())
+			await expect(async () => appliance.stop())
 				.rejects.toBeInstanceOf(NotImplementedError)
 		})
 
 		it('should not throw an error when called with implementation', async () => {
 			const appliance = new FullyImplementedAppliance()
-			expect(await appliance.teardown()).toBeDefined()
+			expect(await appliance.stop()).toBeDefined()
 		})
 	})
 

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -5,9 +5,9 @@ class FullyImplementedAppliance extends IAppliance {
 
 	isValidPayload = async () => true
 
-	setup = async () => null
+	start = async () => true
 
-	teardown = async () => null
+	stop = async () => true
 
 	invoke = async () => true
 


### PR DESCRIPTION
## Description
This PR changes the `setup` and `teardown` methods of IAppliance to `start` and `stop`.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- This is a breaking change.

## Related Issues
Resolves #79 
