### PR TITLE
Make IAppliance a Transform stream

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `IAppliance` no longer has a functioning logger, just a reference to the need for a logger.
 
+### Changed
+- `IAppliance` now extends NodeJS's `stream.Transform`, which means Appliances function as streams instead of simple event emitters.
+
 ## [4.0.0-alpha.2]
 ### Changed
 - Renamed `setup` to `start` and changed its return type.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -2,12 +2,13 @@
 // It will never be referecned, and is defined within the duck typing method.
 /* eslint-disable max-classes-per-file */
 
+import { Transform } from 'stream'
 import {
 	InterfaceInstantiationError,
 	NotImplementedError,
 } from '@tvkitchen/base-errors'
 
-class IAppliance {
+class IAppliance extends Transform {
 	// A logger for use by the Appliance.
 	logger = null
 
@@ -17,8 +18,11 @@ class IAppliance {
    * @param  {Object} settings        Values to override default appliance settings.
    * @param  {Object} settings.logger The logger to use.
 	 */
-	// eslint-disable-next-line no-unused-vars
 	constructor(settings = {}) {
+		super({
+			...settings,
+			objectMode: true,
+		})
 		if (this.constructor === IAppliance) {
 			throw new InterfaceInstantiationError(this.constructor.name)
 		}
@@ -91,18 +95,11 @@ class IAppliance {
 		throw new NotImplementedError('ingestPayload')
 	}
 
-	/**
-	 * Registers a listener to the appliance for a given event type.
-	 *
-	 * Event types are listed in constants/events.js
-	 *
-	 * @param  {String} eventType  The type of event being listened to.
-	 * @param  {Function} listener The listener to be registered for that event.
-	 * @return {EventEmitter}      The EventEmitter (so events can be chained).
-	 */
-	// eslint-disable-next-line no-unused-vars
-	on = (eventType, listener) => {
-		throw new NotImplementedError('on')
+	/** @inheritdoc */
+	_transform = (chunk, encoding, callback) => {
+		this.ingestPayload(chunk)
+			.then(() => callback())
+			.catch((error) => callback(error))
 	}
 
 	/**

--- a/packages/interfaces/src/__test__/IAppliance.test.js
+++ b/packages/interfaces/src/__test__/IAppliance.test.js
@@ -111,18 +111,6 @@ describe('IAppliance', () => {
 		})
 	})
 
-	describe('on', () => {
-		it('should throw an error when called without implementation', () => {
-			const appliance = new PartiallyImplementedAppliance()
-			expect(() => appliance.on()).toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when called with implementation', () => {
-			const appliance = new FullyImplementedAppliance()
-			expect(() => appliance.on()).not.toThrow(NotImplementedError)
-		})
-	})
-
 	describe('duckTypeProperties', () => {
 		it('should contain all properties of an IAppliance', () => {
 			const completePropertySet = new Set([

--- a/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/interfaces/src/__test__/classes/FullyImplementedAppliance.js
@@ -13,8 +13,6 @@ class FullyImplementedAppliance extends IAppliance {
 
 	ingestPayload = async () => true
 
-	on = () => true
-
 	static getInputTypes = () => []
 
 	static getOutputTypes = () => []


### PR DESCRIPTION
## Description
This PR changes IAppliance to make it function as a stream instead of a simple event emitter.  This is a significant change for Appliances and will require modification to AbstractAppliance in order to have it conform to the new model.

Existing appliances will also need to be modified to use things like `this.push` to write new payloads.

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #88 

This includes #89, so please wait to review this until after that plus rebase.
