### PR TITLE
Add Payload data helpers

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Payload` now has two helper methods for setting and accessing `String` and `Object` data that has been stored in the `data` attribute.
+
 ## [1.4.0-alpha.1] - 2020-09-09
 ### Added
 - `AvroPayload` to serialize and deserialize binary data.

--- a/packages/classes/docs/PAYLOAD.md
+++ b/packages/classes/docs/PAYLOAD.md
@@ -32,3 +32,15 @@ For example, if a stream started at 12:00 GMT on March 15th, 2020, a Payload con
 	"position": 120000,
 }
 ```
+
+## Methods
+
+Payload data is a buffer, but can contain more meaningful data (e.g. a `String` or `JSON Stringified Object`). To make accessing this kind of data easier, Payload has two helper getters.  These can be called on payloads whose types are documented to include that data.
+
+- `getDataObject`: Extracts and returns an object that has been stringified within the payload data.
+- `getDataString`: Extracts and returns a string value from payload data.
+
+There are also setters for these types.
+
+- `setDataObject`: Converts a simple object to a buffer and assigns it to payload data.
+- `setDataString`: Converts a string to a buffer and assigns it to the payload data.

--- a/packages/classes/src/Payload.js
+++ b/packages/classes/src/Payload.js
@@ -71,6 +71,36 @@ class Payload {
 		Payload.duckTypeProperties
 			.every((property) => Object.prototype.hasOwnProperty.call(obj, property))
 	)
+
+	/**
+	 * Extracts and returns an object that has been stringified within the payload data.
+	 */
+	getDataObject() {
+		return JSON.parse(this.data.toString())
+	}
+
+	/**
+	 * Extracts and returns a string value from payload data.
+	 */
+	getDataString() {
+		return this.data.toString()
+	}
+
+	/**
+	 * Converts a simple object to a buffer and assigns it to payload data.
+	 *
+	 * The object must be serializable via JSON.stringify / JSON.parse
+	 */
+	setDataObject(obj) {
+		this.data = Buffer.from(JSON.stringify(obj))
+	}
+
+	/**
+	 * Converts a string to a buffer and assigns it to the payload data.
+	 */
+	setDataString(str) {
+		this.data = Buffer.from(str)
+	}
 }
 
 export default Payload

--- a/packages/classes/src/__test__/Payload.unit.test.js
+++ b/packages/classes/src/__test__/Payload.unit.test.js
@@ -159,4 +159,44 @@ describe('Payload', () => {
 			expect(Payload.isPayload(obj)).toBe(false)
 		})
 	})
+
+	describe('getDataObject', () => {
+		it('should return the object representation of stringified json', () => {
+			const dataObject = { a: 'hello' }
+			const payload = new Payload({
+				data: Buffer.from(JSON.stringify(dataObject)),
+			})
+			expect(payload.getDataObject()).toEqual(dataObject)
+		})
+	})
+
+	describe('getDataString', () => {
+		it('should return the buffered string', () => {
+			const dataString = 'hello'
+			const payload = new Payload({
+				data: Buffer.from(dataString),
+			})
+			expect(payload.getDataString()).toEqual(dataString)
+		})
+	})
+
+	describe('setDataObject', () => {
+		it('should store an object in a form that can be deserialized', () => {
+			const dataObject = { a: 'hello' }
+			const payload = new Payload()
+			payload.setDataObject(dataObject)
+			expect(payload.data instanceof Buffer).toBe(true)
+			expect(JSON.parse(payload.data.toString())).toEqual(dataObject)
+		})
+	})
+
+	describe('setDataString', () => {
+		it('should return the buffered string', () => {
+			const dataString = 'hello'
+			const payload = new Payload()
+			payload.setDataString(dataString)
+			expect(payload.data instanceof Buffer).toBe(true)
+			expect(payload.data.toString()).toEqual(dataString)
+		})
+	})
 })


### PR DESCRIPTION
## Description
This PR adds getter / setter helpers to the `Payload` base class, making it a bit easier to work with the `data` attribute of a payload.

## Deploy Notes
- This represents a minor patch.

## Related Issues
Resolves #96 