### PR TITLE
Add PayloadArray time methods

### DIFF
--- a/packages/classes/CHANGELOG.md
+++ b/packages/classes/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Payload` now has two helper methods for setting and accessing `String` and `Object` data that has been stored in the `data` attribute.
+- `PayloadArray` now has several methods making it easier to access the position, timestamp, and duration represented by the collection of Payloads contained.
 
 ## [1.4.0-alpha.1] - 2020-09-09
 ### Added

--- a/packages/classes/docs/PAYLOAD_ARRAY.md
+++ b/packages/classes/docs/PAYLOAD_ARRAY.md
@@ -21,3 +21,7 @@ PayloadArrays have the following methods:
 - `filterByType(type)`: Create a new PayloadArray containing only Payloads of the specified type.
 - `filterByPosition(start, end?)`: Create a new PayloadArray containing only Payloads that exist within a specified duration.
 - `toArray()`: Copy the content of the PayloadArray to a vanilla Array.
+- `empty()`: Remove all payloads from the PayloadArray.
+- `getPosition()`: Get the earliest position represented in this PayloadArray.
+- `getTimestamp()`: Get the earliest timestamp represented in this PayloadArray.
+- `getDuration()`: Get the duration represented by this PayloadArray.

--- a/packages/classes/src/PayloadArray.js
+++ b/packages/classes/src/PayloadArray.js
@@ -30,6 +30,15 @@ class PayloadArray {
 	}
 
 	/**
+	 * Remove all payloads from the PayloadArray.
+	 *
+	 * @return {null}
+	 */
+	empty() {
+		this.payloads = []
+	}
+
+	/**
 	 * Find the index to which a payload with a given position would be inserted.
 	 *
 	 * @param  {Number}  position      The position being searched for.
@@ -80,6 +89,35 @@ class PayloadArray {
 	 * @return {Array} The resulting Array.
 	 */
 	toArray = () => [...this.payloads]
+
+	/**
+	 * Get the earliest position represented in this PayloadArray.
+	 *
+	 * @return {Number} The position of the first payload.
+	 */
+	getPosition() {
+		return this.payloads[0].position
+	}
+
+	/**
+	 * Get the earliest timestamp represented in this PayloadArray.
+	 *
+	 * @return {String} The ISO string of the first payload's timestamp
+	 */
+	getTimestamp() {
+		return this.payloads[0].timestamp
+	}
+
+	/**
+	 * Get the duration represented by this PayloadArray.
+	 *
+	 * @return {Number} The duration covered by this PayloadArray
+	 */
+	getDuration() {
+		const firstPayload = this.payloads[0]
+		const [lastPayload] = this.payloads.slice(-1)
+		return lastPayload.position - firstPayload.position + lastPayload.duration
+	}
 
 	/**
 	 * A comprehensive list of attributes that an object must have to be considered a PayloadArray.

--- a/packages/classes/src/__test__/PayloadArray.unit.test.js
+++ b/packages/classes/src/__test__/PayloadArray.unit.test.js
@@ -173,6 +173,30 @@ describe('PayloadArray', () => {
 		})
 	})
 
+	describe('getPosition', () => {
+		it('should return the position of the earliest payload', () => {
+			const payloadArray = new PayloadArray()
+			payloadArray.insert(new Payload({ position: 2000 }))
+			payloadArray.insert(new Payload({ position: 1000 }))
+			expect(payloadArray.getPosition()).toBe(1000)
+		})
+	})
+	describe('getTimestamp', () => {
+		it('should return the timestamp of the earliest payload', () => {
+			const payloadArray = new PayloadArray()
+			payloadArray.insert(new Payload({ position: 0, timestamp: '2021-03-15T04:05:12.634Z' }))
+			expect(payloadArray.getTimestamp()).toBe('2021-03-15T04:05:12.634Z')
+		})
+	})
+	describe('getDuration', () => {
+		it('should return the full duration of all payloads', () => {
+			const payloadArray = new PayloadArray()
+			payloadArray.insert(new Payload({ position: 4000, duration: 5 }))
+			payloadArray.insert(new Payload({ position: 6000, duration: 3 }))
+			expect(payloadArray.getDuration()).toBe(2003)
+		})
+	})
+
 	describe('duckTypeProperties', () => {
 		it('should contain all properties of a PayloadArray', () => {
 			const completePropertySet = new Set([


### PR DESCRIPTION
## Description
This PR adds several methods making it easy to access the time values associated with a PayloadArray

## Deploy Notes
This represents a minor patch

## Related Issues
Resolves #95