### PR TITLE
Run rimraf on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Bad Idea Factory <biffuddotcom@biffud.com>",
   "license": "LGPL-3.0",
   "scripts": {
-    "build": "yarn workspaces run babel --root-mode upward src -d lib",
+    "clean": "rimraf packages/*/lib",
+    "build": "yarn clean && yarn workspaces run babel --root-mode upward src -d lib",
     "lint": "eslint .",
     "prepare": "yarn build",
     "prepublishOnly": "yarn test && yarn lint",
@@ -33,7 +34,8 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.20.1",
-    "jest": "^25.4.0"
+    "jest": "^25.4.0",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": ">=10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,7 +4439,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
## Description
This PR adds a cleanup step when building.

## Related Issues
This is part of issue #114 since it's part of improving our build processes to support TypeScript
