### PR TITLE
Return a promise in _transform

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Package now specifies Node 10.x or above.
 
+### Fixed
+- Fixed a bug where stream callback was being called by NodeJS directly, resulting in duplicate callback errors ([Issue #124](https://github.com/tvkitchen/base/issues/124))
+
 ## [4.0.0-alpha.4] - 2021-04-16
 ### Changed
 - `IAppliance` class methods are no longer properties / arrow functions.

--- a/packages/interfaces/src/IAppliance.js
+++ b/packages/interfaces/src/IAppliance.js
@@ -101,7 +101,7 @@ class IAppliance extends Transform {
 	/** @inheritdoc */
 	// eslint-disable-next-line no-underscore-dangle
 	async _transform(chunk, encoding, callback) {
-		this.ingestPayload(chunk)
+		return this.ingestPayload(chunk)
 			.then(() => callback())
 			.catch((error) => callback(error))
 	}


### PR DESCRIPTION
This PR fixes an issue where the `_transform` method was not returning the promise.  In more recenve versions of NodeJS this was resulting in the stream callback being called more than once, creating an error.

Resolves #124
